### PR TITLE
Fix tool configuration object shape mismatch

### DIFF
--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -29,7 +29,7 @@ function initializeTools(cornerstoneTools, tools, element) {
   Array.from(tools).forEach(tool => {
     const apiTool = cornerstoneTools[`${tool.name}Tool`] || tool.apiTool;
     if (apiTool) {
-      cornerstoneTools.addToolForElement(element, apiTool, tool.configuration);
+      cornerstoneTools.addToolForElement(element, apiTool, { configuration: tool.configuration });
     } else {
       throw new Error(`Tool not found: ${tool.name}Tool`);
     }


### PR DESCRIPTION
Not sure where the best place to fix this is, but here is the problem:
The `addToolForElement` function takes a `configuration` argument which is then merged with the default config at the tool level, i.e. here: https://github.com/cornerstonejs/cornerstoneTools/blob/8e63394b0656774c86292507c2910f2b23b0abb5/src/tools/ZoomTool.js#L36

The problem is that it looks like most tools `defaultConfig` object have a sub-property `.configuration` that is what should be set by the passed `configuration` in the `addToolForElement` call. So in its current state, the passed configuration properties don't actually have any effect because they are added to the top level of the `defaultConfig` object instead of merged with the sub-property. This change fixes it in the passed parameter, but not sure if it's better to change at the config merge level for each tool? Not sure what the original intent was, if the top level `defaultConfig` properties were meant to be able to be changed with the passed object.