### PR TITLE
chore: add `ViewportOverlay` as a named export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
 import './metadataProvider.js';
 import CornerstoneViewport from './CornerstoneViewport/CornerstoneViewport.js';
 
+import ViewportOverlay from './ViewportOverlay/ViewportOverlay';
+
+export { ViewportOverlay };
+
 export default CornerstoneViewport;


### PR DESCRIPTION
Adds `ViewportOverlay` as a named export of the package, additionally to the default export of `CornerstoneViewport`.

Explicit export would allow downstream users to import and use `ViewportOverlay` separately in their projects (e.g. in OHIF/Viewers extensions or customized overlays) like this:


```jsx
import { ViewportOverlay } from 'react-cornerstone-viewport'

```
Previously it would require including the source code of `react-cornerstone-viewport` into downstream.
