### PR TITLE
Move imageIndex controll into redux store

### DIFF
--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -590,10 +590,8 @@ class CornerstoneViewport extends Component {
 
   onNewImage = event => {
     const { imageId } = event.detail.image;
-    const { sopInstanceUid } = cornerstone.metaData.get(
-      'generalImageModule',
-      imageId
-    );
+    const { sopInstanceUid } =
+      cornerstone.metaData.get('generalImageModule', imageId) || {};
     const currentImageIdIndex = this.props.imageIds.indexOf(imageId);
 
     // TODO: Should we grab and set some imageId specific metadata here?

--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -48,6 +48,7 @@ class CornerstoneViewport extends Component {
     frameRate: PropTypes.number, // Between 1 and ?
     //
     setViewportActive: PropTypes.func, // Called when viewport should be set to active?
+    onNewImage: PropTypes.func,
     viewportOverlayComponent: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func,
@@ -588,14 +589,24 @@ class CornerstoneViewport extends Component {
   };
 
   onNewImage = event => {
-    const newImageId = event.detail.image.imageId;
-    const newImageIdIndex = this.props.imageIds.indexOf(newImageId);
+    const { imageId } = event.detail.image;
+    const { sopInstanceUid } = cornerstone.metaData.get(
+      'generalImageModule',
+      imageId
+    );
+    const currentImageIdIndex = this.props.imageIds.indexOf(imageId);
 
     // TODO: Should we grab and set some imageId specific metadata here?
     // Could prevent cornerstone dependencies in child components.
     this.setState({
-      imageIdIndex: newImageIdIndex,
+      imageIdIndex: currentImageIdIndex,
     });
+
+    if (this.props.onNewImage) {
+      this.props.onNewImage({
+        sopInstanceUid,
+      });
+    }
   };
 
   onImageLoaded = () => {

--- a/src/metadataProvider.js
+++ b/src/metadataProvider.js
@@ -32,6 +32,7 @@ function wadoRsMetaDataProvider(type, imageId) {
 
   if (type === 'generalImageModule') {
     return {
+      sopInstanceUid: getValue(metaData['00080018']),
       instanceNumber: getNumberValue(metaData['00200013']),
       lossyImageCompression: getValue(metaData['00282110']),
       lossyImageCompressionRatio: getValue(metaData['00282112']),


### PR DESCRIPTION
### Changes
- Use imageIdIndex from parent instead of state variable
- Update redux store after image changes (with `sopInstanceUid` and `currentImageIdIndex`)