### PR TITLE
fix(is-playing): CornerstoneViewport now plays the clip on mounting

### DIFF
--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -133,6 +133,8 @@ class CornerstoneViewport extends Component {
       cornerstoneOptions,
       imageIds,
       resizeThrottleMs,
+      isPlaying,
+      frameRate,
     } = this.props;
     const { imageIdIndex } = this.state;
     const imageId = imageIds[imageIdIndex];
@@ -172,6 +174,11 @@ class CornerstoneViewport extends Component {
 
       if (isStackPrefetchEnabled) {
         _enableStackPrefetching(this.element);
+      }
+
+      if (isPlaying) {
+        const validFrameRate = Math.max(frameRate, 1);
+        cornerstoneTools.playClip(this.element, validFrameRate);
       }
 
       _addAndConfigureInitialToolsForElement(tools, this.element);


### PR DESCRIPTION
Fixes #52. 

I observed all the examples, and in my own application, and it appears to work fine. Is there any other testing I should do? 

Also, should we perhaps pull out the validFrameRate into an instance getter? It's used below.