### PR TITLE
target listener became unbound when referenced, avoid unbinding

### DIFF
--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -489,10 +489,9 @@ class CornerstoneViewport extends Component {
     const events = cornerstoneEvents.concat(cornerstoneToolsEvents);
     const targetElementOrCornerstone =
             targetType === 'element' ? this.element : cornerstone.events;
-    const targetListener = targetElementOrCornerstone[addOrRemoveEventListener];
     const boundMethod = this._handleExternalEventListeners.bind(this);
     for (let i = 0; i < events.length; i++) {
-        targetListener(events[i], boundMethod);
+        targetElementOrCornerstone[addOrRemoveEventListener](events[i], boundMethod);
     }
   }
 


### PR DESCRIPTION
In pull request #60 i managed to unbind the event listener with some over zealous rebasing, so when cornerstone events was called to add the new event listeners the following error was called.

```console
Uncaught (in promise) TypeError: Cannot read property 'listeners' of undefined
```

I've reverted a small change and can confirm this now works locally.

I will try and get some tests written in the near future to help avoid this in the future.