### PR TITLE
fix: 🐛 Remove %age loading as not reactive

### DIFF
--- a/src/LoadingIndicator/LoadingIndicator.js
+++ b/src/LoadingIndicator/LoadingIndicator.js
@@ -34,7 +34,6 @@ class LoadingIndicator extends PureComponent {
               <h2>
                 {pc < 100 ? 'Loading...' : 'Loaded -'}
                 <i className="fa fa-spin fa-circle-o-notch fa-fw" />{' '}
-                {percComplete}
               </h2>
               {pc === 100 && <p>Processing...</p>}
             </div>


### PR DESCRIPTION
We already have the option to add a custom component as a loading indicator. But the default one has never had the reactivity to change the %age loading, and images are typically small enough that this is unneeded information, so I'm removing this from the default.