### PR TITLE
Remove stackPrefetch configuration to let apps configure themselves

### DIFF
--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -807,16 +807,7 @@ function _trySetActiveTool(element, activeToolName) {
   });
 }
 
-// TODO: Move configuration elsewhere
-// This is app wide, right?
-// Why would we configure this per element?
 function _enableStackPrefetching(element, clear = false) {
-  cornerstoneTools.stackPrefetch.setConfiguration({
-    maxImagesToPrefetch: Infinity,
-    preserveExistingPool: false,
-    maxSimultaneousRequests: 6,
-  });
-
   if (clear) {
     cornerstoneTools.stackPrefetch.disable(element);
   } else {


### PR DESCRIPTION
Hello, I am an intern at Google currently investigating ways in which to get optimal performance out of medical image viewers that integrate with the Google Healthcare API. This pull request is aimed to help open source medical image viewers get better performance when using this viewport component, by removing the stackPrefetch configuration so that viewers can set the maximum number of simultaneous requests to their preferred setting.

With the introduction of HTTP/2, there is no longer a limit of 6 simultaneous requests to a specific origin. Instead, one connection is made to a given origin and a hypothetically infinite number of requests can be made through that one connection (although browsers such as chrome do eventually limit these connections which appears to be around [100 requests](https://chromium.googlesource.com/chromium/src/+/b10f8ebcdc8deb79d736d6994bd92a6d5a6590ca/net/spdy/spdy_session.h#68)). In practice, changing the maxSimultaneousRequests to values as high as 50 or 75 yields a significant increase in performance on existing medical image viewers such as [Ohif](https://github.com/OHIF/Viewers). Additionally, cornerstoneTools [already has defaults set](https://github.com/cornerstonejs/cornerstoneTools/blob/15120f00786c1418fb06947a369a47acdffde08b/src/util/getMaxSimultaneousRequests.js#L5) for this value that correspond to different browsers, so there should be no need to set this value to 6 manually.

Having this configuration set in the viewport means that it will overwrite the existing configuration of viewers that may want to set the max simultaneous requests to a larger value, which is why I am proposing that these lines be removed so that medical image viewers that utilize this library can set these options themselves outside of the component to find the settings that yield the best performance for them.

I have tested this change with [Ohif](https://github.com/OHIF/Viewers) and the example pages and the viewport still functions as expected. I also tested with different values for `preserveExistingPool` and `maxImagesToPrefetch`. However, as I am not 100% familiar with this codebase, if it is essential to the functionality of this viewport that `maxImagesToPrefetch` is set to `Infinity` and `preserveExistingPool` is set to `false`, then these values can still be set and the `maxSimultaneousRequests` field can be left blank, as seen in the [setConfiguration method in cornerstoneTools](https://github.com/cornerstonejs/cornerstoneTools/blob/15120f00786c1418fb06947a369a47acdffde08b/src/stackTools/stackPrefetch.js#L404). So the below solution could also be used if these two values need to be set to their defaults:
```javascript
cornerstoneTools.stackPrefetch.setConfiguration({
  maxImagesToPrefetch: Infinity,
  preserveExistingPool: false,
});
```