### PR TITLE
Add initial viewport settings 

### DIFF
--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -47,6 +47,7 @@ class CornerstoneViewport extends Component {
     isPlaying: PropTypes.bool,
     frameRate: PropTypes.number, // Between 1 and ?
     //
+    initialViewport: PropTypes.object,
     setViewportActive: PropTypes.func, // Called when viewport should be set to active?
     onNewImage: PropTypes.func,
     onNewImageDebounced: PropTypes.func,
@@ -90,6 +91,7 @@ class CornerstoneViewport extends Component {
     cineFrameRate: 24,
     viewportOverlayComponent: ViewportOverlay,
     imageIds: ['no-id://'],
+    initialViewport: {},
     // Init
     cornerstoneOptions: {},
     isStackPrefetchEnabled: false,
@@ -149,6 +151,7 @@ class CornerstoneViewport extends Component {
       imageIds,
       isPlaying,
       frameRate,
+      initialViewport,
     } = this.props;
     const { imageIdIndex } = this.state;
     const imageId = imageIds[imageIdIndex];
@@ -185,7 +188,7 @@ class CornerstoneViewport extends Component {
 
       // Display
 
-      cornerstone.displayImage(this.element, image);
+      cornerstone.displayImage(this.element, image, initialViewport);
 
       if (isStackPrefetchEnabled) {
         cornerstoneTools.stackPrefetch.enable(this.element);
@@ -210,6 +213,7 @@ class CornerstoneViewport extends Component {
       imageIds: stack,
       imageIdIndex: imageIndex,
       isStackPrefetchEnabled,
+      initialViewport,
     } = this.props;
     const {
       imageIds: prevStack,
@@ -239,7 +243,7 @@ class CornerstoneViewport extends Component {
         cornerstoneTools.stopClip(this.element);
         const image = await cornerstone.loadAndCacheImage(imageId);
 
-        cornerstone.displayImage(this.element, image);
+        cornerstone.displayImage(this.element, image, initialViewport);
         cornerstone.reset(this.element);
       } catch (err) {
         // :wave:


### PR DESCRIPTION
Initial viewport settings such as `voi` can be defined by hanging protocols and we should have a way to initially render the image with this pre-defined settings. This PR addresses this. 
