### PR TITLE
Fix issue #122, deprecated `findDOMNode`

### DIFF
--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -744,7 +744,7 @@ class CornerstoneViewport extends Component {
         style={this.props.style}
         className={classNames('viewport-wrapper', this.props.className)}
       >
-        {this.props.enableResizeDetector && (
+        {this.props.enableResizeDetector && this.element != null && (
           <ReactResizeDetector
             handleWidth
             handleHeight
@@ -752,6 +752,7 @@ class CornerstoneViewport extends Component {
             refreshMode={this.props.resizeRefreshMode}
             refreshRate={this.props.resizeRefreshRateMs}
             onResize={this.onResize}
+            targetDomEl={this.element}
           />
         )}
         <div


### PR DESCRIPTION
Add manual reference to `viewport-element` to prevent calling deprecated `findDOMNode`

Solves #122 