### PR TITLE
Consider scrollbar and marker width when positioning right marker

### DIFF
--- a/src/ViewportOrientationMarkers/ViewportOrientationMarkers.css
+++ b/src/ViewportOrientationMarkers/ViewportOrientationMarkers.css
@@ -1,4 +1,6 @@
 .ViewportOrientationMarkers {
+  --marker-width: 100px;
+  --scrollbar-width: 20px;
   pointer-events: none;
   font-size: 15px;
   color: #ccc;
@@ -15,13 +17,16 @@
   top: 47%;
   left: 5px;
 }
-
 .ViewportOrientationMarkers .right-mid {
   top: 47%;
-  left: 97%;
+  left: calc(100% - var(--marker-width) - var(--scrollbar-width));
 }
-
 .ViewportOrientationMarkers .bottom-mid {
   top: 97%;
   left: 47%;
+}
+.ViewportOrientationMarkers .right-mid .orientation-marker-value {
+  display: flex;
+  justify-content: flex-end;
+  min-width: var(--marker-width);
 }

--- a/src/ViewportOrientationMarkers/ViewportOrientationMarkers.js
+++ b/src/ViewportOrientationMarkers/ViewportOrientationMarkers.js
@@ -121,7 +121,7 @@ class ViewportOrientationMarkers extends PureComponent {
           className={`${m}-mid orientation-marker`}
           key={`${m}-mid orientation-marker`}
         >
-          {markers[m]}
+          <div className="orientation-marker-value">{markers[m]}</div>
         </div>
       ));
 


### PR DESCRIPTION
In small screens or with multiple layout modes where everything is compressed, the right second and third letters are at least partially cut off. This update considers a min-width so the text is always visible.

### Before
![Screen Shot 2021-12-03 at 18 08 09](https://user-images.githubusercontent.com/13886933/144673208-f9c758c0-c006-40e6-92f6-8c378c4752cb.png)
### After
![Screen Shot 2021-12-03 at 18 07 43](https://user-images.githubusercontent.com/13886933/144673197-ec838144-8aa2-4d05-975a-52c9ef08e4b8.png)
