### PR TITLE
fix(ViewportOrientationMarkers): Consider marker height when positioning bottom orientation marker

### DIFF
--- a/src/ViewportOrientationMarkers/ViewportOrientationMarkers.css
+++ b/src/ViewportOrientationMarkers/ViewportOrientationMarkers.css
@@ -1,5 +1,6 @@
 .ViewportOrientationMarkers {
   --marker-width: 100px;
+  --marker-height: 100px;
   --scrollbar-width: 20px;
   pointer-events: none;
   font-size: 15px;
@@ -22,11 +23,17 @@
   left: calc(100% - var(--marker-width) - var(--scrollbar-width));
 }
 .ViewportOrientationMarkers .bottom-mid {
-  top: 97%;
+  top: calc(100% - var(--marker-height) - 5px);
   left: 47%;
 }
 .ViewportOrientationMarkers .right-mid .orientation-marker-value {
   display: flex;
   justify-content: flex-end;
   min-width: var(--marker-width);
+}
+.ViewportOrientationMarkers .bottom-mid .orientation-marker-value {
+  display: flex;
+  justify-content: flex-start;
+  min-height: var(--marker-height);
+  flex-direction: column-reverse;
 }


### PR DESCRIPTION
In small screens or with multiple layout modes where everything is compressed, the right second and
third letters are at least partially cut off. This update considers a min-height so the text is
always visible.