### PR TITLE
Webpack now resolves modules when using yarn link.

### DIFF
--- a/.webpack/webpack.dev.js
+++ b/.webpack/webpack.dev.js
@@ -42,6 +42,7 @@ module.exports = {
       '@cornerstone-viewport': ENTRY_VIEWPORT,
     },
     fallback: { fs: false, path: false },
+    symlinks: false,
   },
   plugins: [
     // Show build progress


### PR DESCRIPTION
When `yarn dev` is run with dependencies linked using `yarn link` those projects are not resolved producing these errors:
![image](https://user-images.githubusercontent.com/22382305/179033193-2a939d0a-a4c9-4c19-bcf1-8ddd0d8aaa1d.png)

This change would resolve this issue.